### PR TITLE
Fix world preview icons after cancelling migration

### DIFF
--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/VoxelMapMigrationFlow.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/VoxelMapMigrationFlow.java
@@ -6,6 +6,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.screens.ConfirmScreen;
 import net.minecraft.client.gui.screens.Screen;
 import net.minecraft.network.chat.Component;
+import org.jspecify.annotations.Nullable;
 
 public final class VoxelMapMigrationFlow {
 
@@ -20,7 +21,11 @@ public final class VoxelMapMigrationFlow {
     private VoxelMapMigrationFlow() {}
 
     public static void start(Screen parent, Component title, Component description, VoxelMapMigration job, boolean showKeepLegacy, Handler handler) {
-        GuiDataMigration dialog = new GuiDataMigration(parent, title, description, showKeepLegacy, choice -> onChoice(title, job, handler, choice), null);
+        start(parent, title, description, job, showKeepLegacy, handler, null);
+    }
+
+    public static void start(Screen parent, Component title, Component description, VoxelMapMigration job, boolean showKeepLegacy, Handler handler, @Nullable Runnable onCancel) {
+        GuiDataMigration dialog = new GuiDataMigration(parent, title, description, showKeepLegacy, choice -> onChoice(title, job, handler, choice), onCancel);
         VoxelConstants.getMinecraft().gui.setScreen(dialog);
     }
 

--- a/common/src/main/java/com/mamiyaotaru/voxelmap/gui/WorldLoadMigrationHook.java
+++ b/common/src/main/java/com/mamiyaotaru/voxelmap/gui/WorldLoadMigrationHook.java
@@ -14,7 +14,7 @@ public final class WorldLoadMigrationHook {
 
     private WorldLoadMigrationHook() {}
 
-    public static boolean interceptWorldLoad(WorldOpenFlows flows, String levelId, Runnable onFail) {
+    public static boolean interceptWorldLoad(WorldOpenFlows flows, String levelId, Runnable onCancel) {
         if (bypass) {
             return false;
         }
@@ -61,17 +61,17 @@ public final class WorldLoadMigrationHook {
 
             @Override
             public void resolved() {
-                resumeWorldLoad(flows, levelId, onFail);
+                resumeWorldLoad(flows, levelId, onCancel);
             }
-        });
+        }, onCancel);
 
         return true;
     }
 
-    private static void resumeWorldLoad(WorldOpenFlows flows, String levelId, Runnable onFail) {
+    private static void resumeWorldLoad(WorldOpenFlows flows, String levelId, Runnable onCancel) {
         bypass = true;
         try {
-            flows.openWorld(levelId, onFail);
+            flows.openWorld(levelId, onCancel);
         } finally {
             bypass = false;
         }


### PR DESCRIPTION
Fixes #123

The migration dialog previously restored the existing world selection screen directly when cancelled.

In Minecraft 26.2, leaving the world selection screen closes the preview favicon textures. Reusing that same screen can therefore leave its world entries referencing closed textures, causing the previews to fall back to the default icon.

This change passes Minecraft's existing `onCancel` callback through `VoxelMapMigrationFlow` to `GuiDataMigration`, so Minecraft returns to the world selection screen through its normal lifecycle.

Tested with Fabric on Minecraft 26.2:

- Cancel keeps the world preview visible
- ESC keeps the world preview visible
- Copy/migration still starts the world normally
- `./gradlew build` succeeds